### PR TITLE
[Automation] Clang Format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+---
+# Global
+BasedOnStyle: Google
+IndentWidth: 4
+---
+# Language specific
+Language: Cpp
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+AccessModifierOffset: -4
+ColumnLimit: 90


### PR DESCRIPTION
Defines automated formatting.

Visual Studio > 15.7 has built in support for this. 
* Go to `Tools -> Options -> C/C++ -> Formatting`
* Tick `Enable ClangFormat support`

Then format with `Ctrl+K Ctrl+D`
Would be awesome if this could be ticked on by default in cmake.
